### PR TITLE
Fix styles in navigation bar

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -98,9 +98,9 @@ const config = {
           {
             to: sponsorUrl,
             'aria-label': 'Sponsor',
-            html: '<i class="fa-regular fa-heart" style="color: #c96198;" />',
+            html: '<i class="fa-regular fa-heart" />',
             position: 'right',
-            className: 'navbar-icon',
+            className: 'navbar-icon sponsor-icon',
           },
           {
             href: gitHubUrl,

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -11,3 +11,7 @@
 .navbar-icon {
   font-size: 24px;
 }
+
+.sponsor-icon {
+  color: #c96198;
+}


### PR DESCRIPTION
Using `style` attribute in HTML on navigation bar makes somehow undesirable effects; use CSS instead.