### PR TITLE
Add contact email link

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -47,6 +47,8 @@ const config = {
     locales: ['en'],
   },
 
+  clientModules: ['/js/unscrambleEmail.js'],
+
   presets: [
     [
       'classic',
@@ -133,6 +135,13 @@ const config = {
             position: 'right',
             className: 'navbar-icon',
           },
+          {
+            href: '/#contact-email',
+            'aria-label': 'Contact Email',
+            html: '<i class="fa-regular fa-envelope"></i>',
+            position: 'right',
+            className: 'navbar-icon',
+          },
         ],
       },
       footer: {
@@ -161,6 +170,15 @@ const config = {
               {
                 label: 'YouTube',
                 href: youtubeUrl,
+              },
+            ],
+          },
+          {
+            title: 'Contact Us',
+            items: [
+              {
+                label: 'Email',
+                href: '/#contact-email',
               },
             ],
           },

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@docusaurus/preset-classic": "^3.4.0",
         "@fortawesome/fontawesome-free": "^6.6.0",
         "@mdx-js/react": "^3.0.1",
+        "botex": "^1.0.0",
         "clsx": "^2.1.1",
         "prism-react-renderer": "^2.3.1",
         "react": "^18.3.1",
@@ -4221,6 +4222,14 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="
+    },
+    "node_modules/botex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/botex/-/botex-1.0.0.tgz",
+      "integrity": "sha512-geklwYrfSahMhNy02OtliwBRrfV8xfJDOw0K7cF+hjeUz3yjBAuCSKGQ5XCF61BrtxodQDs5Pw9SuuXtiOziig==",
+      "bin": {
+        "botex": "dist/botex.mjs"
+      }
     },
     "node_modules/boxen": {
       "version": "6.2.1",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@docusaurus/preset-classic": "^3.4.0",
     "@fortawesome/fontawesome-free": "^6.6.0",
     "@mdx-js/react": "^3.0.1",
+    "botex": "^1.0.0",
     "clsx": "^2.1.1",
     "prism-react-renderer": "^2.3.1",
     "react": "^18.3.1",

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -1,4 +1,5 @@
 import Link from '@docusaurus/Link';
+import useBrokenLinks from '@docusaurus/useBrokenLinks';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import Layout from '@theme/Layout';
 import clsx from 'clsx';
@@ -35,6 +36,9 @@ function HomepageHeader() {
 
 export default function Home() {
   const { siteConfig } = useDocusaurusContext();
+
+  useBrokenLinks().collectAnchor('#contact-email');
+
   return (
     <Layout
       description={siteConfig.customFields.description}>

--- a/static/js/unscrambleEmail.js
+++ b/static/js/unscrambleEmail.js
@@ -1,0 +1,14 @@
+import ExecutionEnvironment from '@docusaurus/ExecutionEnvironment';
+import { unscramble } from 'botex';
+
+const botexKey = 'CHKXRg4cdMZ0XADF';
+const obfuscatedEmail = 'BwC1311181fB4C1sBzmC14162k1dByC112z16132t1o1jBh';
+
+export function onRouteUpdate({ location, previousLocation }) {
+  if (ExecutionEnvironment.canUseDOM) {
+    if (location.pathname === '/' && location.hash === '#contact-email') {
+      const email = unscramble(obfuscatedEmail, botexKey);
+      window.location.href = `mailto:${email}`;
+    }
+  }
+}


### PR DESCRIPTION
This commit adds the project's contact email link to the website navigation bar and footer.

In order to get some protection against email scraping, the email is obfuscated using the `botex` package and only gets unscrambled dynamically, when a user navigates to a special hash link: "/#contact-email".