### PR TITLE
Fix last update time and author on deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,6 +15,10 @@ jobs:
       group: ${{ github.workflow }}-${{ github.ref }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Docusaurus needs the full commit history to correctly
+          # determine the last update time and author.
+          fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
           node-version-file: package.json


### PR DESCRIPTION
Docusaurus needs the full commit history to correctly determine the last update time and author. However, GitHub checkout action only fetches the last commit by default. Configure the checkout action to fetch the full commit history in the deployment workflow.